### PR TITLE
Update automated account blocked by staff PM

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1981,6 +1981,10 @@ en:
 
         This is an automated message from %{site_name} to inform you that your account has been blocked by a staff member.
 
+        Please be aware that you will not be able to create new replies or topics until unblocked by a staff member.
+
+        If you have questions regarding this block, please contact a [staff members](%{base_url}/about).
+
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
 
     user_automatically_blocked:


### PR DESCRIPTION
When a user's account is blocked by staff, they receive an automated PM informing them of such.  Unlike the new user too many flags PM, this PM does not inform that user what blocked means.  This PR adds two lines to the PM, one explaining what blocking means, the other informing the user to contact staff with questions.